### PR TITLE
Linux Compatability.

### DIFF
--- a/lib/spell-check-case.js
+++ b/lib/spell-check-case.js
@@ -21,15 +21,81 @@ export default {
       visible: false
     });
 
+    // load dictionary & known word list for unix systems.
+    this.loadDictionary()
+    this.loadKnownWords()
+
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable();
 
     // Register command that toggles this view
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'spell-check-case:toggle': () => this.toggle(),
-      'spell-check-case-add-word:addWord': () => this.addWord(),
+      'spell-check-case-add-word:addWord': () => {this.addWord(); this.triggerSpellcheck()},
       'core:save': () => this.triggerSpellcheck(),
     }));
+
+    // watch for configuration change
+    this.subscriptions.add(atom.config.onDidChange("spell-check-case.knownWords", (e) => {
+      e.oldValue.forEach((w) => {spellchecker.remove(w)})
+      e.newValue.forEach((w) => {spellchecker.add(w)})
+    }))
+    this.subscriptions.add(atom.config.onDidChange("spell-check-case.locale", (e) => {
+      this.loadDictionary()
+      this.loadKnownWords()
+    }))
+  },
+  // load spellcheck dictionary for unix systems.
+  loadDictionary () {
+    // windows has its own thing, so if windows skip
+    if (process.platform != 'win32') {
+      var sPath = []
+
+      if (process.platform == 'linux') {
+        // paths ripped from, atom spell-check
+        sPath = sPath.concat([
+          '/usr/share/hunspell',
+          '/usr/share/myspell',
+          '/usr/share/myspell/dicts'
+        ])
+      }
+      if (process.platform == 'darwin') {
+        // paths ripped from, atom spell-check
+        sPath = sPath.concat([
+          '/',
+          '/System/Library/Spelling'
+        ])
+      }
+
+      for (var i = 0; i < sPath.length; i++) {
+        if (spellchecker.setDictionary(this.getLocale(), sPath[i])) {
+          break
+        }
+      }
+      // TODO error message on failure to find dictionary
+    }
+  },
+  // load known word list on unix systems
+  loadKnownWords () {
+    // skip if windows, it does its own thing.
+    if (process.platform != 'win32') {
+      var kWords = atom.config.get('spell-check-case.knownWords')
+      if (kWords !== undefined) {
+        kWords.forEach((word) => {
+          spellchecker.add(word)
+        })
+      }
+    }
+  },
+
+  // get locale string. Ex 'en-US'
+  getLocale () {
+    var locale = atom.config.get('spell-check-case.locale')
+    if (locale === undefined || locale === "") {
+      return navigator.language
+    } else {
+      return locale
+    }
   },
   consumeStatusBar(statusBar) {
     statusBar.addLeftTile({item: this.statusBarElement.getElement(), priority: 100});
@@ -39,13 +105,21 @@ export default {
       const word = atom.workspace.getActiveTextEditor().getSelections()[0].getText();
       if (word && typeof word === 'string') {
         spellchecker.add(word);
+        this.saveWord(word)
       }
     } catch (e) {
       // console.log('add word error', e);
       // die quiet
     }
   },
-
+  // save word to the known word list
+  saveWord (word) {
+    var kWords = atom.config.get('spell-check-case.knownWords')
+    if (kWords !== undefined) {
+      kWords.push(word)
+      atom.config.set('spell-check-case.knownWords', kWords)
+    }
+  },
   deactivate() {
     // this.modalPanel.destroy();
     // this.subscriptions.dispose();

--- a/lib/spell-check-case.js
+++ b/lib/spell-check-case.js
@@ -22,7 +22,7 @@ export default {
     });
 
     // load dictionary & known word list for unix systems.
-    this.loadDictionary()
+    this.loadDictionary(true)
     this.loadKnownWords()
 
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
@@ -41,12 +41,12 @@ export default {
       e.newValue.forEach((w) => {spellchecker.add(w)})
     }))
     this.subscriptions.add(atom.config.onDidChange("spell-check-case.locale", (e) => {
-      this.loadDictionary()
+      this.loadDictionary(false)
       this.loadKnownWords()
     }))
   },
   // load spellcheck dictionary for unix systems.
-  loadDictionary () {
+  loadDictionary (bWarn) {
     // windows has its own thing, so if windows skip
     if (process.platform != 'win32') {
       var sPath = []
@@ -69,10 +69,16 @@ export default {
 
       for (var i = 0; i < sPath.length; i++) {
         if (spellchecker.setDictionary(this.getLocale(), sPath[i])) {
-          break
+          return
         }
       }
-      // TODO error message on failure to find dictionary
+
+      // if we are here we failed to load a dictionary
+      if (bWarn) {
+        var msg = "Could not locate dictionary for locale: " + this.getLocale() +
+          " searched path: \n" + sPath
+        atom.notifications.addWarning(msg)
+      }
     }
   },
   // load known word list on unix systems

--- a/menus/spell-check-camel.json
+++ b/menus/spell-check-camel.json
@@ -7,7 +7,7 @@
       },
       {
         "label": "Add Word spell-check-case",
-        "command": "spell-check-case:addWord"
+        "command": "spell-check-case-add-word:addWord"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -21,5 +21,21 @@
   },
   "dependencies": {
     "spellchecker": "^3.3.1"
+  },
+  "configSchema" : {
+    "locale" : {
+      "title": "locale",
+      "type": "string",
+      "description": "locale of the language to spell check (no effect on Windows systems). Some thing like: 'en-US' if blank system default is used",
+      "default": "",
+      "order": 1
+    },
+    "knownWords": {
+      "title": "Known Words",
+      "type": "array",
+      "description": "list of words to ignore during spell checking",
+      "default": [],
+      "order": 2
+    }
   }
 }


### PR DESCRIPTION
First off, love the package. Cant believe this isn't in the default spellchecker. That's why I was so sad when it didn't work on my system (Ubuntu 18.04). These commits fix it! 

The main thing in these commits do is using the undocumented spellchecker.setDictionary() function to bind to system dictionaries (hunspell). This allows spell checking to work on Linux (Not required for Windows).

Additionally, hunspell dictionaries do not persist words added via spellchecker.add() between sessions. To get around this I added a new setting to the package called, "known words". Known words is the list of words the user has added to the dictionary through the AddWord command. This is the same thing found in atom/spell-check   

Changes tested on: Ubuntu 18.04 and MacOs Mojave. 

All the best.
\- Benjamin Benetti